### PR TITLE
Fix CVE-2019-9212

### DIFF
--- a/src/main/resources/security/serialize.blacklist
+++ b/src/main/resources/security/serialize.blacklist
@@ -64,3 +64,5 @@ com.sun.org.apache.xml.internal.security.signature.XMLSignatureInput
 javassist.tools.web.Viewer
 net.bytebuddy.dynamic.loading.ByteArrayClassLoader
 org.apache.commons.beanutils.BeanMap
+com.caucho.naming.Qname
+com.sun.org.apache.xpath.internal.objects.Xstring


### PR DESCRIPTION
Fix  [CVE-2019-9212](https://www.oscs1024.com/hd/CVE-2019-9212) . 

Related Issue: https://github.com/sofastack/sofa-bolt/pull/328

The following things we need to check: 
1. We need to check inner blacklist contains these two class.  @EvenLjj @chuailiwu 
2. Is there a way to share inner blacklist to community? @khotyn @nobodyiam 