### PR TITLE
fix: roll back previous throwable and stack trace element ser for compatibility

### DIFF
--- a/src/main/java/com/caucho/hessian/io/StackTraceElementDeserializer.java
+++ b/src/main/java/com/caucho/hessian/io/StackTraceElementDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2001-2004 Caucho Technology, Inc.  All rights reserved.
+ *
+ * The Apache Software License, Version 1.1
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution, if
+ *    any, must include the following acknowlegement:
+ *       "This product includes software developed by the
+ *        Caucho Technology (http://www.caucho.com/)."
+ *    Alternately, this acknowlegement may appear in the software itself,
+ *    if and wherever such third-party acknowlegements normally appear.
+ *
+ * 4. The names "Hessian", "Resin", and "Caucho" must not be used to
+ *    endorse or promote products derived from this software without prior
+ *    written permission. For written permission, please contact
+ *    info@caucho.com.
+ *
+ * 5. Products derived from this software may not be called "Resin"
+ *    nor may "Resin" appear in their names without prior written
+ *    permission of Caucho Technology.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL CAUCHO TECHNOLOGY OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Scott Ferguson
+ */
+
+package com.caucho.hessian.io;
+
+/**
+ *
+ * @author lo1nt
+ * @version StackTraceElementDeserializer.java, v 0.1 2024-03-08 16:46 lo1nt Exp $
+ */
+@Deprecated
+public class StackTraceElementDeserializer extends
+                                          com.caucho.hessian.io.throwable.StackTraceElementDeserializer {
+}

--- a/src/main/java/com/caucho/hessian/io/ThrowableSerializer.java
+++ b/src/main/java/com/caucho/hessian/io/ThrowableSerializer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2001-2004 Caucho Technology, Inc.  All rights reserved.
+ *
+ * The Apache Software License, Version 1.1
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution, if
+ *    any, must include the following acknowlegement:
+ *       "This product includes software developed by the
+ *        Caucho Technology (http://www.caucho.com/)."
+ *    Alternately, this acknowlegement may appear in the software itself,
+ *    if and wherever such third-party acknowlegements normally appear.
+ *
+ * 4. The names "Burlap", "Resin", and "Caucho" must not be used to
+ *    endorse or promote products derived from this software without prior
+ *    written permission. For written permission, please contact
+ *    info@caucho.com.
+ *
+ * 5. Products derived from this software may not be called "Resin"
+ *    nor may "Resin" appear in their names without prior written
+ *    permission of Caucho Technology.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL CAUCHO TECHNOLOGY OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Scott Ferguson
+ */
+
+package com.caucho.hessian.io;
+
+/**
+ *
+ * @author lo1nt
+ * @version ThrowableSerializer.java, v 0.1 2024-03-08 16:46 lo1nt Exp $
+ */
+@Deprecated
+public class ThrowableSerializer extends com.caucho.hessian.io.throwable.ReflectThrowableSerializer {
+    public ThrowableSerializer(Class<?> clazz) {
+        super(clazz);
+    }
+}

--- a/src/main/java/com/caucho/hessian/io/throwable/ReflectThrowableSerializer.java
+++ b/src/main/java/com/caucho/hessian/io/throwable/ReflectThrowableSerializer.java
@@ -10,7 +10,7 @@ import com.caucho.hessian.io.JavaSerializer;
 import java.io.IOException;
 
 /**
- * use under jdk 17
+ * use under jdk < 17
  * @author junyuan
  * @version ReflectThrowableSerializer.java, v 0.1 2023年05月06日 10:46 junyuan Exp $
  */

--- a/src/main/java/com/caucho/hessian/io/throwable/StackTraceElementDeserializer.java
+++ b/src/main/java/com/caucho/hessian/io/throwable/StackTraceElementDeserializer.java
@@ -82,15 +82,14 @@ public class StackTraceElementDeserializer extends AbstractFieldAdaptorDeseriali
         super(StackTraceElement.class);
 
         try {
-            if (_fields.size() > 4) {
-                // available since java 9
-                _constructorJdk9 = StackTraceElement.class.getDeclaredConstructor(String.class, String.class,
-                    String.class, String.class,
-                    String.class, String.class, int.class);
-            }
             // default, only read class, method, file and line
             _defaultConstructor = StackTraceElement.class.getDeclaredConstructor(String.class, String.class,
                 String.class, int.class);
+            if (_fields.size() > 4) {
+                // available since java 9
+                _constructorJdk9 = StackTraceElement.class.getDeclaredConstructor(String.class, String.class,
+                    String.class, String.class, String.class, String.class, int.class);
+            }
         } catch (Exception e) {
             log.log(Level.FINE, e.toString(), e);
         }

--- a/src/test/java/com/caucho/hessian/io/CompatibleTest.java
+++ b/src/test/java/com/caucho/hessian/io/CompatibleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Ant Group
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.caucho.hessian.io;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ *
+ * @author lo1nt
+ * @version CompatibleTest.java, v 0.1 2024-03-08 16:58 lo1nt Exp $
+ */
+public class CompatibleTest {
+
+    Throwable                            t               = null;
+    private static ByteArrayOutputStream os;
+    private static SerializerFactory factory;
+
+    @BeforeClass
+    public static void setUp() {
+        factory = new TestSerializeFactory();
+        os = new ByteArrayOutputStream();
+    }
+
+    {
+        Throwable x = null;
+        try {
+            x.getStackTrace();
+        } catch (NullPointerException e) {
+            t = e;
+        }
+    }
+
+    @Test
+    public void TestCreateCompatibleClass() {
+        try {
+            ThrowableSerializer ct = new ThrowableSerializer(RuntimeException.class);
+            StackTraceElementDeserializer cs = new StackTraceElementDeserializer();
+        } catch (Throwable t) {
+            Assert.fail("should be no error");
+        }
+    }
+
+    @Test
+    public void TestSerialize() throws IOException {
+        os.reset();
+        Hessian2Output output = new Hessian2Output(os);
+
+        output.setSerializerFactory(factory);
+        output.writeObject(t);
+        output.flush();
+
+        ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
+        Hessian2Input input = new Hessian2Input(is);
+        input.setSerializerFactory(factory);
+        Throwable actual = (Throwable) input.readObject();
+        Assert.assertEquals(t.getStackTrace().length, actual.getStackTrace().length);
+        Assert.assertEquals(t.getMessage(), actual.getMessage());
+    }
+
+    private static class TestSerializeFactory extends SerializerFactory {
+        @Override
+        public Serializer getSerializer(Class cl) throws HessianProtocolException {
+            if (Throwable.class.isAssignableFrom(cl)) {
+                return new ThrowableSerializer(cl);
+            }
+
+            return super.getSerializer(cl);
+        }
+
+        @Override
+        public Deserializer getDeserializer(Class cl) throws HessianProtocolException {
+            if (StackTraceElement.class.isAssignableFrom(cl)) {
+                return new StackTraceElementDeserializer();
+            }
+            return super.getDeserializer(cl);
+        }
+    }
+}

--- a/src/test/java/com/caucho/hessian/io/CompatibleTest.java
+++ b/src/test/java/com/caucho/hessian/io/CompatibleTest.java
@@ -1,6 +1,18 @@
 /*
- * Ant Group
- * Copyright (c) 2004-2024 All Rights Reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.caucho.hessian.io;
 
@@ -19,9 +31,9 @@ import java.io.IOException;
  */
 public class CompatibleTest {
 
-    Throwable                            t               = null;
+    Throwable                            t = null;
     private static ByteArrayOutputStream os;
-    private static SerializerFactory factory;
+    private static SerializerFactory     factory;
 
     @BeforeClass
     public static void setUp() {


### PR DESCRIPTION
add original throwable serializer and stackTraceElement deserializer for compatible use.
