### PR TITLE
optimize performance : Hessian2Input.readObject() for 'B' or 'b'

### DIFF
--- a/src/test/java/com/caucho/hessian/io/Hessian2InputTest.java
+++ b/src/test/java/com/caucho/hessian/io/Hessian2InputTest.java
@@ -1,0 +1,71 @@
+package com.caucho.hessian.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class Hessian2InputTest {
+
+    SerializerFactory serializerFactory = new SerializerFactory();
+
+    @Test
+    public void testSerialize() {
+        byte[] originBytes = generateLargeByteArray(64 * 1024);
+        byte[] encodeBytes = hessianEncodeByte(originBytes);
+        byte[] decodeBytes = hessianDecodeByte(encodeBytes);
+        Assert.assertArrayEquals(originBytes, decodeBytes);
+    }
+
+    @Test
+    public void testSerializeTime() {
+        byte[] originBytes = generateLargeByteArray(1024 * 1024);
+        byte[] encodeBytes = hessianEncodeByte(originBytes);
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 1000; i++) {
+            hessianDecodeByte(encodeBytes);
+        }
+        long end = System.currentTimeMillis();
+        System.out.println("cost:" + (end - start));
+    }
+
+    private static byte[] generateLargeByteArray(int size) {
+        byte[] largeArray = new byte[size];
+        for (int i = 0; i < size; i++) {
+            largeArray[i] = (byte) (i % 256);
+        }
+        return largeArray;
+    }
+
+    private byte[] hessianEncodeByte(byte[] bytes) {
+        serializerFactory.setAllowNonSerializable(true);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        Hessian2Output output = new Hessian2Output(os);
+        output.setSerializerFactory(serializerFactory);
+        try {
+            output.writeObject(bytes);
+            output.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return os.toByteArray();
+    }
+
+    private byte[] hessianDecodeByte(byte[] bytes) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+        Hessian2Input input = new Hessian2Input(bis);
+        input.setSerializerFactory(serializerFactory);
+        byte[] decodeObject;
+        try {
+            decodeObject = (byte[]) input.readObject();
+            input.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return decodeObject;
+    }
+
+}

--- a/src/test/java/com/caucho/hessian/io/Hessian2InputTest.java
+++ b/src/test/java/com/caucho/hessian/io/Hessian2InputTest.java
@@ -11,12 +11,20 @@ public class Hessian2InputTest {
 
     SerializerFactory serializerFactory = new SerializerFactory();
 
+    int[] sizeList = new int[] {
+            0, 2, 16, 512, 1024,
+            0x8000, 0x8000 + 1,
+            64 * 1024, 64 * 1024 * 1024
+    };
+
     @Test
     public void testSerialize() {
-        byte[] originBytes = generateLargeByteArray(64 * 1024);
-        byte[] encodeBytes = hessianEncodeByte(originBytes);
-        byte[] decodeBytes = hessianDecodeByte(encodeBytes);
-        Assert.assertArrayEquals(originBytes, decodeBytes);
+        for (int i = 0; i < sizeList.length; i++) {
+            byte[] originBytes = generateLargeByteArray(sizeList[i]);
+            byte[] encodeBytes = hessianEncodeByte(originBytes);
+            byte[] decodeBytes = hessianDecodeByte(encodeBytes);
+            Assert.assertArrayEquals(originBytes, decodeBytes);
+        }
     }
 
     @Test

--- a/src/test/java/com/caucho/hessian/io/Hessian2InputTest.java
+++ b/src/test/java/com/caucho/hessian/io/Hessian2InputTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.caucho.hessian.io;
 
 import org.junit.Assert;
@@ -11,11 +27,11 @@ public class Hessian2InputTest {
 
     SerializerFactory serializerFactory = new SerializerFactory();
 
-    int[] sizeList = new int[] {
-            0, 2, 16, 512, 1024,
-            0x8000, 0x8000 + 1,
-            64 * 1024, 64 * 1024 * 1024
-    };
+    int[]             sizeList          = new int[] {
+                                        0, 2, 16, 512, 1024,
+                                        0x8000, 0x8000 + 1,
+                                        64 * 1024, 64 * 1024 * 1024
+                                        };
 
     @Test
     public void testSerialize() {


### PR DESCRIPTION
这是一个对Hessian读取大byte[]的性能优化。读取耗时较优化前降低80%以上。

【优化原理】
原始读取逻辑：每次从流中读取256字节，然后处理后，放入一个新的ByteArrayOutputStream，如此循环后，最后再用ByteArrayOutputStream生成一个大的byte[]
本次优化：
1、对于只有一个chunk（总字节长度小于等于32768）的字节数组，不需要额外生成ByteArrayOutputStream了，而是直接读取chunk头上的字节长度，一次性生成固定长度的byte[]。然后将buffer中已经读取的一部分先写入到byte[]中，最后计算剩余应该从is流中读取的字节长度，使用_is.read(目标数组, 目标数组偏移量, 读取长度)的方法，一次性读取。
2、对于有多个chunk的字节数组，每个chunk使用上述步骤一次性读取，然后放入到ByteArrayOutputStream，多个chunk读取完成后，通过ByteArrayOutputStream输出拼接的byte[]


数据正确性测试：Hessian2InputTest.testSerialize()
简单的性能测试：Hessian2InputTest.testSerializeTime()



MacBook M1，测试结果如下：

单chunk的情况：反序列化byte[1024]， 10000次：
优化前：56ms
优化后：36ms

单chunk的情况：反序列化byte[10*1024]， 10000次：
优化前：312ms
优化后：40ms

单chunk的情况：反序列化byte[32000]， 10000次：
优化前：824ms   （随字节长度线性增长）
优化后：54ms     （几乎无增长）

多chunk的情况：反序列化byte[1024*1024]， 10000次：
优化前：24609ms
优化后：2225ms  （降低90%）
