### PR TITLE
Defer security blacklist check to improve performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>hessian</artifactId>
-    <version>3.5.5</version>
+    <version>3.5.6</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/caucho/hessian/io/Hessian2Input.java
+++ b/src/main/java/com/caucho/hessian/io/Hessian2Input.java
@@ -85,7 +85,7 @@ public class Hessian2Input
 
     private static Field        _detailMessageField;
 
-    private static final int    SIZE        = 256;
+    private static final int    SIZE        = 1024;
     private static final int    GAP         = 16;
 
     // factory for deserializing objects in the input stream

--- a/src/main/java/com/caucho/hessian/io/SerializerFactory.java
+++ b/src/main/java/com/caucho/hessian/io/SerializerFactory.java
@@ -486,6 +486,13 @@ public class SerializerFactory extends AbstractSerializerFactory
         if (type == null || type.equals(""))
             return null;
 
+        Deserializer deserializer;
+
+        deserializer = (Deserializer) _cachedTypeDeserializerMap.get(type);
+
+        if (deserializer != null)
+            return deserializer;
+
         if (classNameResolver != null) {
             try {
                 type = classNameResolver.resolve(type);
@@ -493,13 +500,6 @@ public class SerializerFactory extends AbstractSerializerFactory
                 throw new HessianProtocolException(e);
             }
         }
-
-        Deserializer deserializer;
-
-        deserializer = (Deserializer) _cachedTypeDeserializerMap.get(type);
-
-        if (deserializer != null)
-            return deserializer;
 
         deserializer = (Deserializer) _staticTypeMap.get(type);
         if (deserializer != null)


### PR DESCRIPTION
主要是把黑名单的安全检查挪到从缓存中获取 Deserializer 后面了，这样每次获取 Deserializer 的时候就不用反复跑安全检查了，第一次来获取 Deserializer 必定会获取不到缓存，这个时候再走安全检查的逻辑；